### PR TITLE
remove locks on container init as there is no other option

### DIFF
--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,3 @@
+rm -f $HOME/.config/darktable/library.db.lock
+rm -f $HOME/.config/darktable/data.db.lock
 darktable


### PR DESCRIPTION
Darktable is prone to not shutting down properly on SIGTERM, this can leave lock files which will splash the user with a scary message. This only removes them if they exist on startup which is harmless as it is a fresh container and there are no pids to conflict with. 