### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=darktable \
-    NO_GAMEPAD=true
+    NO_GAMEPAD=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,7 +11,8 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=darktable \
-    NO_GAMEPAD=true
+    NO_GAMEPAD=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **28.12.25:** - Add Wayland init logic.
 * **12.07.25:** - Rebase to Selkies, HTTPS IS NOW REQUIRED.
 * **10.02.24:** - Update Readme with new env vars and ingest proper PWA icon.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -103,6 +103,7 @@ init_diagram: |
   "darktable:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "12.07.25:", desc: "Rebase to Selkies, HTTPS IS NOW REQUIRED."}
   - {date: "10.02.24:", desc: "Update Readme with new env vars and ingest proper PWA icon."}

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,3 +1,3 @@
 rm -f $HOME/.config/darktable/library.db.lock
 rm -f $HOME/.config/darktable/data.db.lock
-foot -e darktable
+darktable

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -2,6 +2,6 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
-<item label="Darktable" icon="/usr/share/icons/hicolor/scalable/apps/darktable.svg"><action name="Execute"><command>xterm -e /usr/bin/darktable</command></action></item>
+<item label="Darktable" icon="/usr/share/icons/hicolor/scalable/apps/darktable.svg"><action name="Execute"><command>/usr/bin/darktable</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
Basic wayland cutover, terminal wrapper not needed anymore with the interposer disabled. 